### PR TITLE
Match cluster color to "worst" of point colors

### DIFF
--- a/shinyapp/app.R
+++ b/shinyapp/app.R
@@ -1050,6 +1050,15 @@ server <- function(input, output, session) {
                                               # popup = ~html_popups,
                                               label = lapply(sensor_locations_labels,HTML),
                                               labelOptions = labelOptions(direction = "top", style=list("border-radius" = "10px")),
+                                              clusterId = "place",
+                                              layerId = sensor_locations$sensor_ID,
+                                              color = "black",
+                                              fillColor = sensor_locations %>%
+                                                left_join(isolate(map_flood_status_reactive()), by = "sensor_ID") %>%
+                                                left_join(tibble("flood_status" = c("UNKNOWN","FLOODING", "WARNING", "NOT FLOODING"),
+                                                                 "flood_color" = c("grey", "#dc3545", "#ffc107", "#28a745")), by = "flood_status") %>% 
+                                                pull(flood_color),
+                                              ,
                                               clusterOptions = markerClusterOptions(iconCreateFunction=JS("function (cluster) {    
                                                 var markers = cluster.getAllChildMarkers();
                                                 var childCount = cluster.getChildCount();
@@ -1073,15 +1082,7 @@ server <- function(input, output, session) {
                                                   }
                                                 }
                                                 return new L.DivIcon({ html: '<div style=\"background-color:'+c+'\"><span>' + childCount + '</span></div>', className: 'marker-cluster', iconSize: new L.Point(40, 40)});
-                                              }")),
-                                              clusterId = "place",
-                                              layerId = sensor_locations$sensor_ID,
-                                              color = "black",
-                                              fillColor = sensor_locations %>%
-                                                left_join(isolate(map_flood_status_reactive()), by = "sensor_ID") %>%
-                                                left_join(tibble("flood_status" = c("UNKNOWN","FLOODING", "WARNING", "NOT FLOODING"),
-                                                                 "flood_color" = c("grey", "#dc3545", "#ffc107", "#28a745")), by = "flood_status") %>% 
-                                                pull(flood_color),
+                                              }"))
                                               fillOpacity = 1) %>% 
                              # leaflet::addLegend('bottomright', pal = pal_rev, values = c(-3.5,0.5),
                              #                    title = 'Water level<br>relative to<br>surface (ft)',

--- a/shinyapp/app.R
+++ b/shinyapp/app.R
@@ -1058,7 +1058,6 @@ server <- function(input, output, session) {
                                                 left_join(tibble("flood_status" = c("UNKNOWN","FLOODING", "WARNING", "NOT FLOODING"),
                                                                  "flood_color" = c("grey", "#dc3545", "#ffc107", "#28a745")), by = "flood_status") %>% 
                                                 pull(flood_color),
-                                              ,
                                               clusterOptions = markerClusterOptions(iconCreateFunction=JS("function (cluster) {    
                                                 var markers = cluster.getAllChildMarkers();
                                                 var childCount = cluster.getChildCount();
@@ -1082,7 +1081,7 @@ server <- function(input, output, session) {
                                                   }
                                                 }
                                                 return new L.DivIcon({ html: '<div style=\"background-color:'+c+'\"><span>' + childCount + '</span></div>', className: 'marker-cluster', iconSize: new L.Point(40, 40)});
-                                              }"))
+                                              }")),
                                               fillOpacity = 1) %>% 
                              # leaflet::addLegend('bottomright', pal = pal_rev, values = c(-3.5,0.5),
                              #                    title = 'Water level<br>relative to<br>surface (ft)',

--- a/shinyapp/app.R
+++ b/shinyapp/app.R
@@ -1058,24 +1058,25 @@ server <- function(input, output, session) {
                                                 left_join(tibble("flood_status" = c("UNKNOWN","FLOODING", "WARNING", "NOT FLOODING"),
                                                                  "flood_color" = c("grey", "#dc3545", "#ffc107", "#28a745")), by = "flood_status") %>% 
                                                 pull(flood_color),
-                                              clusterOptions = markerClusterOptions(iconCreateFunction=JS("function (cluster) {    
+                                              # color markerClusters to match markers using color assignments from fillColor
+                                              clusterOptions = markerClusterOptions(iconCreateFunction=JS("function (cluster) {   
                                                 var markers = cluster.getAllChildMarkers();
                                                 var childCount = cluster.getChildCount();
                                                 var p = 0; 
                                                 for (i = 0; i < markers.length; i++) {
-                                                  if(markers[i].options.col === '#dc3545'){ # look first for a red marker
-                                                    c = '#dc3545';
+                                                  if(markers[i].options.col === '#dc3545'){ 
+                                                    c = '#dc3545'; 
                                                     break;
                                                   }
-                                                  else if(markers[i].options.col === '#ffc107'){ # look next for yellow
+                                                  else if(markers[i].options.col === '#ffc107'){ 
                                                     c = '#ffc107';
                                                     break;
                                                   }
-                                                  else if(markers[i].options.col === '#28a745'){ # look next for green
+                                                  else if(markers[i].options.col === '#28a745'){ 
                                                     c = '#28a745';
                                                     break;
                                                   }
-                                                  else(markers[i].options.col === 'grey'){ # if all are grey, use grey
+                                                  else(markers[i].options.col === 'grey'){ 
                                                     c = 'grey';
                                                     break;
                                                   }

--- a/shinyapp/app.R
+++ b/shinyapp/app.R
@@ -1050,7 +1050,30 @@ server <- function(input, output, session) {
                                               # popup = ~html_popups,
                                               label = lapply(sensor_locations_labels,HTML),
                                               labelOptions = labelOptions(direction = "top", style=list("border-radius" = "10px")),
-                                              clusterOptions = markerClusterOptions(),
+                                              clusterOptions = markerClusterOptions(iconCreateFunction=JS("function (cluster) {    
+                                                var markers = cluster.getAllChildMarkers();
+                                                var childCount = cluster.getChildCount();
+                                                var p = 0; 
+                                                for (i = 0; i < markers.length; i++) {
+                                                  if(markers[i].options.col === '#dc3545'){ # look first for a red marker
+                                                    c = '#dc3545';
+                                                    break;
+                                                  }
+                                                  else if(markers[i].options.col === '#ffc107'){ # look next for yellow
+                                                    c = '#ffc107';
+                                                    break;
+                                                  }
+                                                  else if(markers[i].options.col === '#28a745'){ # look next for green
+                                                    c = '#28a745';
+                                                    break;
+                                                  }
+                                                  else(markers[i].options.col === 'grey'){ # if all are grey, use grey
+                                                    c = 'grey';
+                                                    break;
+                                                  }
+                                                }
+                                                return new L.DivIcon({ html: '<div style=\"background-color:'+c+'\"><span>' + childCount + '</span></div>', className: 'marker-cluster', iconSize: new L.Point(40, 40)});
+                                              }")),
                                               clusterId = "place",
                                               layerId = sensor_locations$sensor_ID,
                                               color = "black",


### PR DESCRIPTION
Quick attempt to change cluster colors such that they match the worst (i.e., highest alert level) of the individual markers. That is, if any of markers in a cluster is red, the whole cluster should show up as red. If not, but a marker is yellow, whole cluster shows as yellow, etc. 

I apologize for a somewhat lazy PR. It looked tough to set up a proper dev environment, so I just made some untested code changes that look like they could be headed in the right direction. Hope I don't set you off on a wild goose chase and of course no worries if it's not worth testing on your end. 

Happy to look into this more if you think it could help but this proposed solution doesn't work. ~ Phil